### PR TITLE
optionally expose the internal buffer size to the user (if they need it)

### DIFF
--- a/async-sockets/include/basesocket.hpp
+++ b/async-sockets/include/basesocket.hpp
@@ -17,6 +17,10 @@
 #define FDR_UNUSED(expr){ (void)(expr); } 
 #define FDR_ON_ERROR std::function<void(int, std::string)> onError = [](int errorCode, std::string errorMessage){FDR_UNUSED(errorCode); FDR_UNUSED(errorMessage)}
 
+#ifndef AS_DEFAULT_BUFFER_SIZE
+#define AS_DEFAULT_BUFFER_SIZE 0x1000 /*4096 bytes*/
+#endif
+
 class BaseSocket
 {
 public:
@@ -26,7 +30,6 @@ public:
         UDP = SOCK_DGRAM
     };
     sockaddr_in address;
-    constexpr static uint16_t BUFFER_SIZE = 0x1000; // 4096 bytes
 
     void Close() {
         shutdown(this->sock, SHUT_RDWR);

--- a/async-sockets/include/tcpserver.hpp
+++ b/async-sockets/include/tcpserver.hpp
@@ -3,11 +3,12 @@
 #include "tcpsocket.hpp"
 #include <thread>
 
+template <uint16_t BUFFER_SIZE = AS_DEFAULT_BUFFER_SIZE>
 class TCPServer : public BaseSocket
 {
 public:
     // Event Listeners:
-    std::function<void(TCPSocket*)> onNewConnection = [](TCPSocket* sock){FDR_UNUSED(sock)};
+    std::function<void(TCPSocket<BUFFER_SIZE>*)> onNewConnection = [](TCPSocket<BUFFER_SIZE>* sock){FDR_UNUSED(sock)};
 
     explicit TCPServer(FDR_ON_ERROR): BaseSocket(onError, SocketType::TCP)
     {
@@ -57,7 +58,7 @@ public:
     }
 
 private:
-    static void Accept(TCPServer* server, FDR_ON_ERROR)
+    static void Accept(TCPServer<BUFFER_SIZE>* server, FDR_ON_ERROR)
     {
         sockaddr_in newSocketInfo;
         socklen_t newSocketInfoLength = sizeof(newSocketInfo);
@@ -75,7 +76,7 @@ private:
                 return;
             }
 
-            TCPSocket* newSocket = new TCPSocket(onError, newSocketFileDescriptor);
+            TCPSocket<BUFFER_SIZE>* newSocket = new TCPSocket<BUFFER_SIZE>(onError, newSocketFileDescriptor);
             newSocket->deleteAfterClosed = true;
             newSocket->setAddressStruct(newSocketInfo);
 

--- a/async-sockets/include/tcpsocket.hpp
+++ b/async-sockets/include/tcpsocket.hpp
@@ -6,6 +6,7 @@
 #include <functional>
 #include <thread>
 
+template <uint16_t BUFFER_SIZE = AS_DEFAULT_BUFFER_SIZE>
 class TCPSocket : public BaseSocket
 {
 public:
@@ -22,7 +23,6 @@ public:
     ssize_t Send(const std::string& message) { return this->Send(message.c_str(), message.length()); }
 
     // Connect to a TCP Server with `uint32_t ipv4` & `uint16_t port` values
-    template <uint16_t BUFFER_SIZE = AS_DEFAULT_BUFFER_SIZE>
     void Connect(uint32_t ipv4, uint16_t port, std::function<void()> onConnected = [](){}, FDR_ON_ERROR)
     {
         this->address.sin_family = AF_INET;
@@ -46,10 +46,9 @@ public:
         onConnected();
 
         // Start listening from server:
-        this->Listen<BUFFER_SIZE>();
+        this->Listen();
     }
     // Connect to a TCP Server with `const char* host` & `uint16_t port` values
-    template <uint16_t BUFFER_SIZE = AS_DEFAULT_BUFFER_SIZE>
     void Connect(const char* host, uint16_t port, std::function<void()> onConnected = [](){}, FDR_ON_ERROR)
     {
         struct addrinfo hints, *res, *it;
@@ -74,20 +73,18 @@ public:
 
         freeaddrinfo(res);
 
-        this->Connect<BUFFER_SIZE>((uint32_t)this->address.sin_addr.s_addr, port, onConnected, onError);
+        this->Connect((uint32_t)this->address.sin_addr.s_addr, port, onConnected, onError);
     }
     // Connect to a TCP Server with `const std::string& ipv4` & `uint16_t port` values
-    template <uint16_t BUFFER_SIZE = AS_DEFAULT_BUFFER_SIZE>
     void Connect(const std::string& host, uint16_t port, std::function<void()> onConnected = [](){}, FDR_ON_ERROR)
     {
-        this->Connect<BUFFER_SIZE>(host.c_str(), port, onConnected, onError);
+        this->Connect(host.c_str(), port, onConnected, onError);
     }
 
     // Start another thread to listen the socket
-    template <uint16_t BUFFER_SIZE = AS_DEFAULT_BUFFER_SIZE>
     void Listen()
     {
-        std::thread t(TCPSocket::Receive<BUFFER_SIZE>, this);
+        std::thread t(TCPSocket::Receive, this);
         t.detach();
     }
 
@@ -97,7 +94,6 @@ public:
     bool deleteAfterClosed = false;
 
 private:
-    template <uint16_t BUFFER_SIZE>
     static void Receive(TCPSocket* socket)
     {
         char tempBuffer[BUFFER_SIZE];

--- a/async-sockets/include/udpserver.hpp
+++ b/async-sockets/include/udpserver.hpp
@@ -3,7 +3,8 @@
 #include "udpsocket.hpp"
 #include <thread>
 
-class UDPServer : public UDPSocket
+template <uint16_t BUFFER_SIZE = AS_DEFAULT_BUFFER_SIZE>
+class UDPServer : public UDPSocket<BUFFER_SIZE>
 {
 public:
     // Bind the custom address & port of the server.

--- a/async-sockets/include/udpsocket.hpp
+++ b/async-sockets/include/udpsocket.hpp
@@ -4,24 +4,23 @@
 #include <string.h>
 #include <thread>
 
+template <uint16_t BUFFER_SIZE = AS_DEFAULT_BUFFER_SIZE>
 class UDPSocket : public BaseSocket
 {
 public:
     std::function<void(std::string, std::string, std::uint16_t)> onMessageReceived;
     std::function<void(const char*, ssize_t, std::string, std::uint16_t)> onRawMessageReceived;
 
-    template <uint16_t BUFFER_SIZE = AS_DEFAULT_BUFFER_SIZE>
     explicit UDPSocket(bool useConnect = false, FDR_ON_ERROR, int socketId = -1): BaseSocket(onError, SocketType::UDP, socketId)
     {
         if (useConnect)
         {
-            
-            std::thread t(Receive<BUFFER_SIZE>, this); // usage with Connect()
+            std::thread t(Receive, this); // usage with Connect()
             t.detach();
         }
         else
         {
-            std::thread t(ReceiveFrom<BUFFER_SIZE>, this);
+            std::thread t(ReceiveFrom, this);
             t.detach();
         }
     }
@@ -134,7 +133,6 @@ public:
     void Connect(const std::string& host, uint16_t port, FDR_ON_ERROR) { this->Connect(host.c_str(), port, onError); }
 
 private:
-    template <uint16_t BUFFER_SIZE>
     static void Receive(UDPSocket* udpSocket)
     {
         char tempBuffer[BUFFER_SIZE];
@@ -151,7 +149,6 @@ private:
         }
     }
 
-    template <uint16_t BUFFER_SIZE>
     static void ReceiveFrom(UDPSocket* udpSocket)
     {
         sockaddr_in hostAddr;

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,22 +1,24 @@
 CC		:= g++
 CFLAGS	:= --std=c++11 -Wall -Wextra -Werror=conversion
 LIBS	:= -lpthread
-INC		:= -I../async-sockets/include
+INC		:= ../async-sockets/include
 RM		:= rm
+
+.PHONY: all clean
 
 all: tcp-client tcp-server udp-client udp-server
 
-tcp-client:
-	$(CC) $(CFLAGS) tcp-client.cpp $(INC) $(LIBS) -o tcp-client
+tcp-client: tcp-client.cpp $(INC)/tcpsocket.hpp
+	$(CC) $(CFLAGS) $< -I$(INC) $(LIBS) -o $@
 
-tcp-server:
-	$(CC) $(CFLAGS) tcp-server.cpp $(INC) $(LIBS) -o tcp-server
+tcp-server: tcp-server.cpp $(INC)/tcpserver.hpp
+	$(CC) $(CFLAGS) $< -I$(INC) $(LIBS) -o $@
 
-udp-client:
-	$(CC) $(CFLAGS) udp-client.cpp $(INC) $(LIBS) -o udp-client
+udp-client: udp-client.cpp $(INC)/udpsocket.hpp
+	$(CC) $(CFLAGS) $< -I$(INC) $(LIBS) -o $@
 
-udp-server:
-	$(CC) $(CFLAGS) udp-server.cpp $(INC) $(LIBS) -o udp-server
+udp-server: udp-server.cpp $(INC)/udpserver.hpp
+	$(CC) $(CFLAGS) $< -I$(INC) $(LIBS) -o $@
 
 clean:
 	$(RM) tcp-client

--- a/examples/tcp-client.cpp
+++ b/examples/tcp-client.cpp
@@ -6,7 +6,7 @@ using namespace std;
 int main()
 {
     // Initialize socket.
-    TCPSocket tcpSocket([](int errorCode, std::string errorMessage){
+    TCPSocket<> tcpSocket([](int errorCode, std::string errorMessage){
         cout << "Socket creation error:" << errorCode << " : " << errorMessage << endl;
     });
 
@@ -26,7 +26,7 @@ int main()
     };
 
     // Connect to the host (with a custom buffer size).
-    tcpSocket.Connect<0xFFFF>("localhost", 8888, [&] {
+    tcpSocket.Connect("localhost", 8888, [&] {
         cout << "Connected to the server successfully." << endl;
 
         // Send String:

--- a/examples/tcp-client.cpp
+++ b/examples/tcp-client.cpp
@@ -1,4 +1,4 @@
-#include "../async-sockets/include/tcpsocket.hpp"
+#include "tcpsocket.hpp"
 #include <iostream>
 
 using namespace std;
@@ -25,8 +25,8 @@ int main()
         cout << "Connection closed: " << errorCode << endl;
     };
 
-    // Connect to the host.
-    tcpSocket.Connect("localhost", 8888, [&] {
+    // Connect to the host (with a custom buffer size).
+    tcpSocket.Connect<0xFFFF>("localhost", 8888, [&] {
         cout << "Connected to the server successfully." << endl;
 
         // Send String:

--- a/examples/tcp-server.cpp
+++ b/examples/tcp-server.cpp
@@ -6,10 +6,10 @@ using namespace std;
 int main()
 {
     // Initialize server socket..
-    TCPServer tcpServer;
+    TCPServer<> tcpServer;
 
     // When a new client connected:
-    tcpServer.onNewConnection = [&](TCPSocket *newClient) {
+    tcpServer.onNewConnection = [&](TCPSocket<> *newClient) {
         cout << "New client: [";
         cout << newClient->remoteAddress() << ":" << newClient->remotePort() << "]" << endl;
 

--- a/examples/tcp-server.cpp
+++ b/examples/tcp-server.cpp
@@ -1,4 +1,4 @@
-#include "../async-sockets/include/tcpserver.hpp"
+#include "tcpserver.hpp"
 #include <iostream>
 
 using namespace std;

--- a/examples/udp-client.cpp
+++ b/examples/udp-client.cpp
@@ -10,7 +10,7 @@ int main()
     constexpr uint16_t PORT = 8888;
 
     // Initialize socket.
-    UDPSocket udpSocket(true); // "true" to use Connection on UDP. Default is "false".
+    UDPSocket<100> udpSocket(true); // "true" to use Connection on UDP. Default is "false".
     udpSocket.Connect(IP, PORT);
 
     // Send String:

--- a/examples/udp-client.cpp
+++ b/examples/udp-client.cpp
@@ -1,4 +1,4 @@
-#include "../async-sockets/include/udpsocket.hpp"
+#include "udpsocket.hpp"
 #include <iostream>
 
 using namespace std;

--- a/examples/udp-server.cpp
+++ b/examples/udp-server.cpp
@@ -6,7 +6,7 @@ using namespace std;
 int main()
 {
     // Initialize server socket..
-    UDPServer udpServer;
+    UDPServer<> udpServer;
 
     // onMessageReceived will run when a message received with information of ip & port of sender:
     /*udpServer.onMessageReceived = [&](string message, string ipv4, uint16_t port) {

--- a/examples/udp-server.cpp
+++ b/examples/udp-server.cpp
@@ -1,4 +1,4 @@
-#include "../async-sockets/include/udpserver.hpp"
+#include "udpserver.hpp"
 #include <iostream>
 
 using namespace std;


### PR DESCRIPTION
API should be the same but now, if you want to, you can specify the internal buffer size.
Included it in one of the examples.
Murdered the makefile...you don't have to keep that part...

fixes #29